### PR TITLE
fix exploit for A6/A6X and Pre-9.3b3

### DIFF
--- a/Exploits/Phoenix Exploit/exploit.m
+++ b/Exploits/Phoenix Exploit/exploit.m
@@ -78,18 +78,194 @@ void resume_all_threads() {
     }
 }
 
-uint32_t find_kerneltask(){
-    // A5:
-    return 0x8041200c;
-    // A6:
-    // return 0x8041a00c;
+#import <UIKit/UIKit.h>
+#include <sys/utsname.h>
+#include <sys/sysctl.h>
+
+uint32_t find_kerneltask(void){
+    struct utsname systemInfo;
+    uname(&systemInfo);
+    NSArray *isA5orA5X = [NSArray arrayWithObjects:@"iPad2,1",@"iPad2,2",@"iPad2,3",@"iPad2,4",@"iPad2,5",@"iPad2,6",@"iPad2,7",@"iPad3,1",@"iPad3,2",@"iPad3,3",@"iPhone4,1",@"iPod5,1", nil];
+    size_t size;
+    sysctlbyname("kern.version", NULL, &size, NULL, 0);
+    char *kernelVersion = malloc(size);
+    sysctlbyname("kern.version", kernelVersion, &size, NULL, 0);
+    olog("%s\n",kernelVersion);
+    
+    char *newkernv = malloc(size - 44);
+    char *semicolon = strchr(kernelVersion, '~');
+    int indexofsemi = (int)(semicolon - kernelVersion);
+    int indexofrootxnu = indexofsemi;
+    while (kernelVersion[indexofrootxnu - 1] != '-') {
+        indexofrootxnu -= 1;
+    }
+    memcpy(newkernv, &kernelVersion[indexofrootxnu], indexofsemi - indexofrootxnu + 2);
+    newkernv[indexofsemi - indexofrootxnu + 2] = '\0';
+    NSString *KernelVersion = [NSString stringWithUTF8String:newkernv];
+    if([isA5orA5X containsObject:[NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding]]) {
+        if ([[NSArray arrayWithObjects:@"3248.61.1~1",@"3248.60.9~1",@"3248.60.8~1",@"3248.60.4~1",@"3248.60.3~3",@"3248.50.21~4",@"3248.50.20~1",@"3248.50.18~1",@"3248.41.4~2",@"3248.41.4~3",@"3248.41.3~1",@"3248.40.173.0.1~1",@"3248.40.166.0.1~1",@"3248.40.155.1.1~3", nil] containsObject:KernelVersion]) { //9.3b1-9.3.6
+            return 0x8041200c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.21.1~2",@"3248.21.2~1", nil] containsObject:KernelVersion]) { //9.2b3-9.2.1
+            return 0x8040b00c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.20.39~8", nil] containsObject:KernelVersion]) { //9.2b2
+            return 0x8040a00c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.20.33.0.1~7", nil] containsObject:KernelVersion]) { //9.2b1
+            return 0x8041600c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.10.42~4",@"3248.10.41~1",@"3248.10.38~3",@"3248.10.27~1", nil] containsObject:KernelVersion]){ //9.1b1-9.1
+            return 0x8041400c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.1.3~1",@"3248.1.2~3",@"3247.1.88.1.1~1", nil] containsObject:KernelVersion]) { //9.0b5-9.0.2
+            return 0x8041300c;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.56~1", nil] containsObject:KernelVersion]) { //9.0b4
+            return 0x8041100c;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.36.0.1~9", nil] containsObject:KernelVersion]) { //9.0b3
+            return 0x8041200c;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.6.1.1~2", nil] containsObject:KernelVersion]) { //9.0b2
+            return 0x80417098;
+        }
+        if ([[NSArray arrayWithObjects:@"3216.0.0.1.15~2", nil] containsObject:KernelVersion]) { //9.0b1
+            return 0x80414098;
+        }
+        return 0x8041200c;
+    } else {
+        if ([[NSArray arrayWithObjects:@"3248.61.1~1",@"3248.60.9~1",@"3248.60.8~1",@"3248.60.4~1",@"3248.60.3~3",@"3248.50.21~4",@"3248.50.20~1",@"3248.50.18~1",@"3248.41.4~2",@"3248.41.4~3",@"3248.41.3~1",@"3248.40.173.0.1~1",@"3248.40.166.0.1~1",@"3248.40.155.1.1~3", nil] containsObject:KernelVersion]) { //9.3b1-9.3.6
+            return 0x8041a00c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.31.3~2",@"3248.21.2~1",@"3248.21.1~2",@"3248.20.39~8", nil] containsObject:KernelVersion]) { //9.2b2-9.2.1
+            return 0x8041200c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.20.33.0.1~7", nil] containsObject:KernelVersion]) { //9.2b1
+            return 0x8041e00c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.10.42~4",@"3248.10.41~1",@"3248.10.38~3", nil] containsObject:KernelVersion]) { //9.1b3-9.1 (assume 9.1b2)
+            return 0x8041b00c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.10.27~1", nil] containsObject:KernelVersion]) { //9.1b1
+            return 0x8041a00c;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.1.3~1",@"3248.1.2~3",@"3247.1.88.1.1~1", nil] containsObject:KernelVersion]) { //9.0b5-9.0.2
+            return 0x8041900c;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.56~1", nil] containsObject:KernelVersion]) { //9.0b4
+            return 0x8041800c;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.36.0.1~9", nil] containsObject:KernelVersion]) { //9.0b3
+            return 0x8041a00c;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.6.1.1~2", nil] containsObject:KernelVersion]) { //9.0b2
+            return 0x8041f098;
+        }
+        if ([[NSArray arrayWithObjects:@"3216.0.0.1.15~2", nil] containsObject:KernelVersion]) { //9.0b1
+            return 0x8041b098;
+        }
+        return 0x8041a00c;
+    }
 }
 
-uint32_t find_ipcspacekernel(){
-    // A5:
-    return 0x80456664;
-    // A6:
-    // return 0x8045e798;
+uint32_t find_ipcspacekernel(void){
+    struct utsname systemInfo;
+    uname(&systemInfo);
+    NSArray *isA5orA5X = [NSArray arrayWithObjects:@"iPad2,1",@"iPad2,2",@"iPad2,3",@"iPad2,4",@"iPad2,5",@"iPad2,6",@"iPad2,7",@"iPad3,1",@"iPad3,2",@"iPad3,3",@"iPhone4,1",@"iPod5,1", nil];
+    size_t size;
+    sysctlbyname("kern.version", NULL, &size, NULL, 0);
+    char *kernelVersion = malloc(size);
+    sysctlbyname("kern.version", kernelVersion, &size, NULL, 0);
+    olog("%s\n",kernelVersion);
+    
+    char *newkernv = malloc(size - 44);
+    char *semicolon = strchr(kernelVersion, '~');
+    int indexofsemi = (int)(semicolon - kernelVersion);
+    int indexofrootxnu = indexofsemi;
+    while (kernelVersion[indexofrootxnu - 1] != '-') {
+        indexofrootxnu -= 1;
+    }
+    memcpy(newkernv, &kernelVersion[indexofrootxnu], indexofsemi - indexofrootxnu + 2);
+    newkernv[indexofsemi - indexofrootxnu + 2] = '\0';
+    NSString *KernelVersion = [NSString stringWithUTF8String:newkernv];
+    if([isA5orA5X containsObject:[NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding]]) {
+        if ([[NSArray arrayWithObjects:@"3248.61.1~1",@"3248.60.9~1",@"3248.60.8~1",@"3248.60.4~1",@"3248.60.3~3",@"3248.50.21~4",@"3248.50.20~1",@"3248.50.18~1",@"3248.41.4~2",@"3248.41.4~3",@"3248.41.3~1", nil] containsObject:KernelVersion]) { //9.3b4-9.3.6
+            return 0x80456664;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.40.173.0.1~1",@"3248.40.166.0.1~1", nil] containsObject:KernelVersion]) { //9.3b1-9.3b3
+            return 0x80456674;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.31.3~2",@"3248.21.2~1",@"3248.21.1~2", nil] containsObject:KernelVersion]) { //9.2b3-9.2.1
+            return 0x8044f660;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.20.39~8", nil] containsObject:KernelVersion]) { //9.2b2
+            return 0x8044de60;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.20.33.0.1~7", nil] containsObject:KernelVersion]) { //9.2b1
+            return 0x80459e60;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.10.42~4",@"3248.10.41~1",@"3248.10.38~3", nil] containsObject:KernelVersion]) { //9.1b2-9.1
+            return 0x80457e50;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.10.27~1", nil] containsObject:KernelVersion]) { //9.1b1
+            return 0x80457dd0;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.1.3~1",@"3248.1.2~3",@"3247.1.88.1.1~1", nil] containsObject:KernelVersion]) { //9.0b5-9.0.2
+            return 0x80456dc0;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.56~1", nil] containsObject:KernelVersion]) { //9.0b4
+            return 0x80454d44;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.36.0.1~9", nil] containsObject:KernelVersion]) { //9.0b3
+            return 0x80455d34;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.6.1.1~2", nil] containsObject:KernelVersion]) { //9.0b2
+            return 0x8045cc10;
+        }
+        if ([[NSArray arrayWithObjects:@"3216.0.0.1.15~2", nil] containsObject:KernelVersion]) { //9.0b1
+            return 0x80459af4;
+        }
+        return 0x80456664;
+    } else {
+        if ([[NSArray arrayWithObjects:@"3248.61.1~1",@"3248.60.9~1",@"3248.60.8~1",@"3248.60.4~1",@"3248.60.3~3",@"3248.50.21~4",@"3248.50.20~1",@"3248.50.18~1",@"3248.41.4~2",@"3248.41.4~3",@"3248.41.3~1",@"3248.40.173.0.1~1",@"3248.40.166.0.1~1",@"3248.40.155.1.1~3", nil] containsObject:KernelVersion]) { //9.3b1-9.3.6
+            return 0x8045e798;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.31.3~2",@"3248.21.2~1",@"3248.21.1~2", nil] containsObject:KernelVersion]) { //9.2b3-9.2.1
+            return 0x80456784;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.20.39~8", nil] containsObject:KernelVersion]) { //9.2b2
+            return 0x80455f84;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.20.33.0.1~7", nil] containsObject:KernelVersion]) { //9.2b1
+            return 0x80461f84;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.10.42~4",@"3248.10.41~1",@"3248.10.38~3", nil] containsObject:KernelVersion]) { //9.1b3-9.1 (assume 9.1b2)
+            return 0x8045ef74;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.10.42~4",@"3248.10.41~1",@"3248.10.38~3", nil] containsObject:KernelVersion]) { //9.1b3-9.1 (assume 9.1b2)
+            return 0x8045ef74;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.10.27~1", nil] containsObject:KernelVersion]) { //9.1b1
+            return 0x8045def4;
+        }
+        if ([[NSArray arrayWithObjects:@"3248.1.3~1",@"3248.1.2~3",@"3247.1.88.1.1~1", nil] containsObject:KernelVersion]) { //9.0b5-9.0.2
+            return 0x8045cee4;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.56~1", nil] containsObject:KernelVersion]) { //9.0b4
+            return 0x8045be68;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.36.0.1~9", nil] containsObject:KernelVersion]) { //9.0b3
+            return 0x8045de58;
+        }
+        if ([[NSArray arrayWithObjects:@"3247.1.6.1.1~2", nil] containsObject:KernelVersion]) { //9.0b2
+            return 0x80464d34;
+        }
+        if ([[NSArray arrayWithObjects:@"3216.0.0.1.15~2", nil] containsObject:KernelVersion]) { //9.0b1
+            return 0x80460c18;
+        }
+        return 0x8045e798;
+    }
 }
 
 #define SIZEOF_BYTES_MSG 384


### PR DESCRIPTION
(you may know me better by my former u, zachary7829)

in openpwnage beta 6 I messed up and included hardcoded offsets in the exploit, accidentally messing up compatibility for A6/A6X devices and pre-iOS 9.3b3 firmwares. I quickly fixed this mistake later on and updated openpwnage. this does the exact same thing for blizzard. (also, #if __arm7s__ for whatever reason didn't detect for my test iPad 4, so I just reused the same isA5orA5X method :P)